### PR TITLE
Add .gitlab-ci.yml file

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,129 @@
+# DESCRIPTION: GitLab CI/CD for libRetro (NOT FOR GitLab-proper)
+
+# Core definitions
+.core-defs:
+  variables:
+    MAKEFILE: Makefile.libretro
+    CORENAME: same_cdi
+
+# Core definitions
+include:
+  ################################## DESKTOPS ################################
+  # Windows 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/windows-x64-mingw.yml'
+
+  # # Windows 32-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/windows-i686-mingw.yml'
+
+  # Linux 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-x64.yml'
+
+  # Linux 32-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-i686.yml'
+
+  # MacOS 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/osx-x64.yml'
+
+  ################################## CELLULAR ################################
+  # Android
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/android-make.yml'
+
+# Stages for building
+stages:
+  - build-prepare
+  - build-shared
+
+# Cache
+# Need to set a proper key in each job
+cache: &global_cache
+  untracked: true
+  paths:
+    - build/
+
+##############################################################################
+#################################### STAGES ##################################
+##############################################################################
+
+################################### DESKTOPS #################################
+# Windows 64-bit
+libretro-build-windows-x64:
+  extends:
+    - .libretro-windows-x64-mingw-make-default
+    - .core-defs
+  cache:
+    <<: *global_cache
+    key: "$CI_COMMIT_REF_SLUG-windows-x64"
+
+# Windows 32-bit
+libretro-build-windows-i686:
+  extends:
+    - .libretro-windows-i686-mingw-make-default
+    - .core-defs
+  cache:
+    <<: *global_cache
+    key: "$CI_COMMIT_REF_SLUG-windows-i686"
+
+# Linux 64-bit
+libretro-build-linux-x64:
+  extends:
+    - .libretro-linux-x64-make-default
+    - .core-defs
+  cache:
+    <<: *global_cache
+    key: "$CI_COMMIT_REF_SLUG-linux-x64"
+
+# Linux 32-bit
+libretro-build-linux-i686:
+  extends:
+    - .libretro-linux-i686-make-default
+    - .core-defs
+  cache:
+    <<: *global_cache
+    key: "$CI_COMMIT_REF_SLUG-linux-i686"
+
+# MacOS 64-bit
+libretro-build-osx-x64:
+  tags:
+    - macosx-packaging
+  extends:
+    - .libretro-osx-x64-make-default
+    - .core-defs
+  variables:
+    MACOSX_DEPLOYMENT_TARGET: "10.14"
+  cache:
+    <<: *global_cache
+    key: "$CI_COMMIT_REF_SLUG-osx-x64"
+
+################################### CELLULAR #################################
+# Android ARMv7a
+android-armeabi-v7a:
+  extends:
+    - .libretro-android-make-armeabi-v7a
+    - .core-defs
+  cache:
+    <<: *global_cache
+    key: "$CI_COMMIT_REF_SLUG-android-armeabi-v7a"
+
+# Android ARMv8a
+android-arm64-v8a:
+  extends:
+    - .libretro-android-make-arm64-v8a
+    - .core-defs
+  cache:
+    <<: *global_cache
+    key: "$CI_COMMIT_REF_SLUG-android-arm64-v8a"
+
+# Android 64-bit x86
+android-x86_64:
+  extends:
+    - .libretro-android-make-x86_64
+    - .core-defs
+  cache:
+    <<: *global_cache
+    key: "$CI_COMMIT_REF_SLUG-android-x86_64"

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -233,6 +233,7 @@ build:
 	@mv $(SUBTARGET)_libretro.dylib $(SAME_SYSTEM)_libretro.dylib 2> /dev/null || true
 	@mv $(SUBTARGET)_libretro.dll $(SAME_SYSTEM)_libretro.dll 2> /dev/null || true
 	@mv $(SUBTARGET)_libretro.so $(SAME_SYSTEM)_libretro.so 2> /dev/null || true
+	@mv $(SUBTARGET)_libretro_android.so $(SAME_SYSTEM)_libretro_android.so 2> /dev/null || true
 	@echo "Done!"
 
 vs2015:


### PR DESCRIPTION
This PR adds a `.gitlab-ci.yml` file and fixes renaming of generated Android binaries