### PR TITLE
Add Nintendo Switch support (libnx)

### DIFF
--- a/3rdparty/linenoise/linenoise.c
+++ b/3rdparty/linenoise/linenoise.c
@@ -114,9 +114,11 @@
 //#define snprintf _snprintf
 #endif
 #else
+#ifndef __DEVKITPRO__
 #include <termios.h>
 #include <sys/ioctl.h>
 #include <poll.h>
+#endif
 #define USE_TERMIOS
 #define HAVE_UNISTD_H
 #endif
@@ -248,7 +250,9 @@ static int checkForColor(const char *buf, int *colors, int *size)
 
 #if defined(USE_TERMIOS)
 static void linenoiseAtExit(void);
+#ifndef __DEVKITPRO__
 static struct termios orig_termios; /* in order to restore at exit */
+#endif
 static int rawmode = 0; /* for atexit() function to check if restore is needed*/
 static int atexit_registered = 0; /* register atexit just 1 time */
 
@@ -269,6 +273,7 @@ static int isUnsupportedTerm(void) {
 }
 
 static int enableRawMode(struct current *current) {
+#ifndef __DEVKITPRO__
     struct termios raw;
 
     current->fd = STDIN_FILENO;
@@ -280,12 +285,14 @@ fatal:
         errno = ENOTTY;
         return -1;
     }
+#endif
 
     if (!atexit_registered) {
         atexit(linenoiseAtExit);
         atexit_registered = 1;
     }
 
+#ifndef __DEVKITPRO__
     raw = orig_termios;  /* modify the original mode */
     /* input modes: no break, no CR to NL, no parity check, no strip char,
      * no start/stop output control. */
@@ -306,20 +313,25 @@ fatal:
         goto fatal;
     }
     rawmode = 1;
+#endif
     return 0;
 }
 
 static void disableRawMode(struct current *current) {
+#ifndef __DEVKITPRO__
     /* Don't even check the return value as it's too late. */
     if (rawmode && tcsetattr(current->fd,TCSADRAIN,&orig_termios) != -1)
         rawmode = 0;
+#endif
 }
 
 /* At exit we'll try to fix the terminal to the initial conditions. */
 static void linenoiseAtExit(void) {
+#ifndef __DEVKITPRO__
     if (rawmode) {
         tcsetattr(STDIN_FILENO, TCSADRAIN, &orig_termios);
     }
+#endif
     linenoiseHistoryFree();
 }
 
@@ -388,8 +400,9 @@ static void setCursorPos(struct current *current, int x)
  */
 static int fd_read_char(int fd, int timeout)
 {
-    struct pollfd p;
     unsigned char c;
+#ifndef __DEVKITPRO__
+    struct pollfd p;
 
     p.fd = fd;
     p.events = POLLIN;
@@ -398,6 +411,7 @@ static int fd_read_char(int fd, int timeout)
         /* timeout */
         return -1;
     }
+#endif
     if (read(fd, &c, 1) != 1) {
         return -1;
     }
@@ -410,8 +424,9 @@ static int fd_read_char(int fd, int timeout)
  */
 static int fd_read(struct current *current)
 {
-    struct pollfd p;
     int ret;
+#ifndef __DEVKITPRO__
+    struct pollfd p;
     p.fd = current->fd;
     p.events = POLLIN;
     while(1) {
@@ -427,6 +442,7 @@ static int fd_read(struct current *current)
         else
             break;
     }
+#endif
 #ifdef USE_UTF8
     char buf[4];
     int n;
@@ -499,12 +515,14 @@ static int queryCursor(int fd, int* cols)
  */
 static int getWindowSize(struct current *current)
 {
+#ifndef __DEVKITPRO__
     struct winsize ws;
 
     if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == 0 && ws.ws_col != 0) {
         current->cols = ws.ws_col;
         return 0;
     }
+#endif
 
     /* Failed to query the window size. Perhaps we are on a serial terminal.
      * Try to query the width by sending the cursor as far to the right

--- a/3rdparty/lsqlite3/lsqlite3.c
+++ b/3rdparty/lsqlite3/lsqlite3.c
@@ -1209,6 +1209,7 @@ static int db_create_collation(lua_State *L) {
     return 0;
 }
 
+#ifndef __DEVKITPRO__
 /* Thanks to Wolfgang Oertl...
 */
 static int db_load_extension(lua_State *L) {
@@ -1236,6 +1237,7 @@ static int db_load_extension(lua_State *L) {
     sqlite3_free(errmsg);
     return 2;
 }
+#endif
 
 /*
 ** trace callback:
@@ -2192,7 +2194,9 @@ static const luaL_Reg dblib[] = {
     {"create_function",     db_create_function      },
     {"create_aggregate",    db_create_aggregate     },
     {"create_collation",    db_create_collation     },
+#ifndef __DEVKITPRO__
     {"load_extension",      db_load_extension       },
+#endif
 
     {"trace",               db_trace                },
     {"progress_handler",    db_progress_handler     },

--- a/3rdparty/sqlite3/sqlite3.c
+++ b/3rdparty/sqlite3/sqlite3.c
@@ -926,7 +926,9 @@ SQLITE_PRIVATE const char **sqlite3CompileOptions(int *pnOpt){
 #else
 /* This is not VxWorks. */
 #define OS_VXWORKS 0
+#ifndef __DEVKITPRO__
 #define HAVE_FCHOWN 1
+#endif
 #define HAVE_READLINK 1
 #define HAVE_LSTAT 1
 #endif /* defined(_WRS_KERNEL) */
@@ -33440,7 +33442,9 @@ SQLITE_PRIVATE const char *sqlite3OpcodeName(int i){
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#ifdef SQLITE_ENABLE_BATCH_ATOMIC_WRITE
 #include <sys/ioctl.h>
+#endif
 #include <unistd.h>
 /* #include <time.h> */
 #include <sys/time.h>

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -151,8 +151,11 @@ ifeq ($(platform),android-x86_64)
 	PTR64 :=
 endif
 
-ifeq ($(platform),libnx)
+ifeq ($(platform),linux32)
 	PTR64 := 0
+endif
+
+ifeq ($(platform),libnx)
 	PLATFLAGS += TARGETOS="libnx" PLATFORM="arm64" FORCE_DRC_C_BACKEND="1"
 	LIBRETRO_CPU :=
 	ARCH :=

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -151,8 +151,13 @@ ifeq ($(platform),android-x86_64)
 	PTR64 :=
 endif
 
-ifeq ($(platform),linux32)
+ifeq ($(platform),libnx)
 	PTR64 := 0
+	PLATFLAGS += TARGETOS="libnx" PLATFORM="arm64" FORCE_DRC_C_BACKEND="1"
+	LIBRETRO_CPU :=
+	ARCH :=
+	LIBRETRO_OS :=
+	PTR64 :=
 endif
 
 ifeq ($(platform),osx)
@@ -243,6 +248,7 @@ build:
 	@mv $(SUBTARGET)_libretro.dll $(SAME_SYSTEM)_libretro.dll 2> /dev/null || true
 	@mv $(SUBTARGET)_libretro.so $(SAME_SYSTEM)_libretro.so 2> /dev/null || true
 	@mv $(SUBTARGET)_libretro_android.so $(SAME_SYSTEM)_libretro_android.so 2> /dev/null || true
+	@mv $(SUBTARGET)_libretro.a $(SAME_SYSTEM)_libretro.a 2> /dev/null || true
 	@echo "Done!"
 
 vs2015:

--- a/makefile
+++ b/makefile
@@ -1437,7 +1437,7 @@ openbsd_x86: generate $(PROJECTDIR)/$(MAKETYPE)-openbsd/Makefile
 	$(SILENT) $(MAKE) -C $(PROJECTDIR)/$(MAKETYPE)-openbsd config=$(CONFIG)32
 
 #-------------------------------------------------
-# gmake-linux
+# libnx
 #-------------------------------------------------
 
 $(PROJECTDIR)/$(MAKETYPE)-libnx/Makefile: makefile $(SCRIPTS) $(GENIE)

--- a/makefile
+++ b/makefile
@@ -1437,6 +1437,18 @@ openbsd_x86: generate $(PROJECTDIR)/$(MAKETYPE)-openbsd/Makefile
 	$(SILENT) $(MAKE) -C $(PROJECTDIR)/$(MAKETYPE)-openbsd config=$(CONFIG)32
 
 #-------------------------------------------------
+# gmake-linux
+#-------------------------------------------------
+
+$(PROJECTDIR)/$(MAKETYPE)-libnx/Makefile: makefile $(SCRIPTS) $(GENIE)
+	$(SILENT) $(GENIE) $(PARAMS) $(TARGET_PARAMS) --gcc=libnx --gcc_version=$(GCC_VERSION) $(MAKETYPE)
+
+.PHONY: libnx-arm64
+libnx: generate $(PROJECTDIR)/$(MAKETYPE)-libnx/Makefile
+	$(SILENT) $(MAKE) $(MAKEPARAMS) -C $(PROJECTDIR)/$(MAKETYPE)-libnx-arm64 config=$(CONFIG) precompile
+	$(SILENT) $(MAKE) $(MAKEPARAMS) -C $(PROJECTDIR)/$(MAKETYPE)-libnx-arm64 config=$(CONFIG)
+
+#-------------------------------------------------
 # Clean/bootstrap
 #-------------------------------------------------
 

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -126,6 +126,7 @@ newoption {
 		{ "windows",       "Windows"                },
 		{ "haiku",         "Haiku"                  },
 		{ "solaris",       "Solaris SunOS"          },
+		{ "libnx",         "libnx"                  },
 	},
 }
 

--- a/scripts/src/3rdparty.lua
+++ b/scripts/src/3rdparty.lua
@@ -857,7 +857,7 @@ end
 			"LUA_COMPAT_5_1",
 			"LUA_COMPAT_5_2",
 		}
-	if not (_OPTIONS["targetos"]=="windows") and not (_OPTIONS["targetos"]=="asmjs") then
+	if not (_OPTIONS["targetos"]=="windows") and not (_OPTIONS["targetos"]=="asmjs") and not (_OPTIONS["targetos"]=="libnx") then
 		defines {
 			"LUA_USE_POSIX",
 		}
@@ -981,6 +981,10 @@ if _OPTIONS["vs"]=="clangcl" then
 end
 
 	configuration { }
+	defines {
+		"SQLITE_OMIT_WAL",
+		"SQLITE_OMIT_LOAD_EXTENSION",
+	}
 
 	files {
 		MAME_DIR .. "3rdparty/sqlite3/sqlite3.c",

--- a/scripts/src/main.lua
+++ b/scripts/src/main.lua
@@ -24,7 +24,11 @@ else
 	project (_subtarget)
 end
 	uuid (os.uuid(_target .."_" .. _subtarget))
-	kind "ConsoleApp"
+	if _OPTIONS["targetos"]=="libnx" then
+		kind "StaticLib"
+	else
+		kind "ConsoleApp"
+	end
 
 	configuration { "android*" }
 	linkoptions {
@@ -65,7 +69,9 @@ end
 		targetextension ".bc"
 	-- BEGIN libretro overrides to MAME's GENie build
 	configuration { "libretro*" }
-		kind "SharedLib"	
+		if _OPTIONS["targetos"]~="libnx" then
+			kind "SharedLib"
+		end
 		targetsuffix "_libretro"
 		if _OPTIONS["targetos"]=="android" then
 			targetsuffix "_libretro_android"

--- a/scripts/src/osd/retro.lua
+++ b/scripts/src/osd/retro.lua
@@ -55,9 +55,10 @@ if BASE_TARGETOS=="unix" then
 					"nsl",
 				}
 			else
-				links {
-					"util",
-				}
+				-- What are you needed for? nobody knows...
+				-- links {
+				-- 	"util",
+				-- }
 			end
 		end
 	

--- a/scripts/toolchain.lua
+++ b/scripts/toolchain.lua
@@ -33,6 +33,7 @@ newoption {
 		{ "osx",           "OSX (GCC compiler)"     },
 		{ "osx-clang",     "OSX (Clang compiler)"   },
 		{ "solaris",       "Solaris"                },
+		{ "libnx",         "libnx"                  },
 	},
 }
 
@@ -207,6 +208,13 @@ function toolchain(_buildDir, _subDir)
 			premake.gcc.cxx = toolchainPrefix .. "clang++"
 			premake.gcc.ar  = toolchainPrefix .. "ar"
 			location (_buildDir .. "projects/" .. _subDir .. "/".. _ACTION .. "-osx-clang")
+		end
+
+		if "libnx" == _OPTIONS["gcc"] then
+			premake.gcc.cc  = "aarch64-none-elf-gcc"
+			premake.gcc.cxx = "aarch64-none-elf-g++"
+			premake.gcc.ar  = "aarch64-none-elf-ar"
+			location (_buildDir .. "projects/" .. _subDir .. "/".. _ACTION .. "-libnx-arm64")
 		end
 	elseif _ACTION == "vs2019" then
 
@@ -686,6 +694,38 @@ function toolchain(_buildDir, _subDir)
 	configuration { "rpi" }
 		targetdir (_buildDir .. "rpi" .. "/bin")
 		objdir (_buildDir .. "rpi" .. "/obj")
+
+	configuration { "libnx" }
+		systemincludedirs {
+			"/opt/devkitpro/libnx/include",
+			"/opt/devkitpro/portlibs/switch/include",
+		}
+		defines {
+			"LLONG_MAX=0x7fffffffffffffffLL",
+			"LLONG_MIN=-0x8000000000000000LL",
+			"ULLONG_MAX=0xffffffffffffffffLL",
+		}
+		libdirs {
+			"/opt/devkitpro/libnx/lib",
+			"/opt/devkitpro/portlibs/switch/lib",
+		}
+		links {
+			"nx",
+		}
+		buildoptions {
+			"-g -ffunction-sections",
+			"-march=armv8-a -mtune=cortex-a57 -mtp=soft",
+		}
+		buildoptions_cpp {
+			-- Added by libretro-super, but we seem to need these
+			-- "-fno-rtti -fno-exceptions",
+		}
+		linkoptions {
+			"-specs=/opt/devkitpro/libnx/switch.specs",
+			"-march=armv8-a -mtune=cortex-a57 -mtp=soft",
+			"-ftls-model=local-exec",
+		}
+
 -- BEGIN libretro overrides to MAME's GENie build
 
 	configuration { "libretro*" }

--- a/src/osd/modules/file/posixdir.cpp
+++ b/src/osd/modules/file/posixdir.cpp
@@ -69,7 +69,7 @@ constexpr char PATHSEPCH = '\\';
 constexpr char PATHSEPCH = '/';
 #endif
 
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__bsdi__) || defined(__DragonFly__) || defined(__EMSCRIPTEN__) || defined(__ANDROID__) || defined(_WIN32) || defined(SDLMAME_NO64BITIO)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__bsdi__) || defined(__DragonFly__) || defined(__EMSCRIPTEN__) || defined(__ANDROID__) || defined(_WIN32) || defined(SDLMAME_NO64BITIO) || defined(__DEVKITPRO__)
 using sdl_dirent = struct dirent;
 using sdl_stat = struct stat;
 #define sdl_readdir readdir

--- a/src/osd/modules/file/posixfile.cpp
+++ b/src/osd/modules/file/posixfile.cpp
@@ -102,7 +102,7 @@ public:
 
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__bsdi__) || defined(__DragonFly__) || defined(__EMSCRIPTEN__) || defined(__ANDROID__)
 		result = ::pread(m_fd, buffer, size_t(count), off_t(std::make_unsigned_t<off_t>(offset)));
-#elif defined(_WIN32) || defined(SDLMAME_NO64BITIO)
+#elif defined(_WIN32) || defined(SDLMAME_NO64BITIO) || defined(__DEVKITPRO__)
 		if (lseek(m_fd, off_t(std::make_unsigned_t<off_t>(offset)), SEEK_SET) < 0)
 			return std::error_condition(errno, std::generic_category());
 		result = ::read(m_fd, buffer, size_t(count));
@@ -123,7 +123,7 @@ public:
 
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__bsdi__) || defined(__DragonFly__) || defined(__EMSCRIPTEN__) || defined(__ANDROID__)
 		result = ::pwrite(m_fd, buffer, size_t(count), off_t(std::make_unsigned_t<off_t>(offset)));
-#elif defined(_WIN32) || defined(SDLMAME_NO64BITIO)
+#elif defined(_WIN32) || defined(SDLMAME_NO64BITIO) || defined(__DEVKITPRO__)
 		if (lseek(m_fd, off_t(std::make_unsigned_t<off_t>(offset)), SEEK_SET) < 0)
 			return std::error_condition(errno, std::generic_category());
 		result = ::write(m_fd, buffer, size_t(count));
@@ -142,7 +142,7 @@ public:
 	{
 		int result;
 
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__bsdi__) || defined(__DragonFly__) || defined(__EMSCRIPTEN__) || defined(_WIN32) || defined(SDLMAME_NO64BITIO) || defined(__ANDROID__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__bsdi__) || defined(__DragonFly__) || defined(__EMSCRIPTEN__) || defined(_WIN32) || defined(SDLMAME_NO64BITIO) || defined(__ANDROID__) || defined(__DEVKITPRO__)
 		result = ::ftruncate(m_fd, off_t(std::make_unsigned_t<off_t>(offset)));
 #else
 		result = ::ftruncate64(m_fd, off64_t(offset));
@@ -262,7 +262,7 @@ std::error_condition osd_file::open(std::string const &path, std::uint32_t openf
 
 	// attempt to open the file
 	int fd = -1;
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__bsdi__) || defined(__DragonFly__) || defined(__HAIKU__) || defined(_WIN32) || defined(SDLMAME_NO64BITIO) || defined(__ANDROID__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__bsdi__) || defined(__DragonFly__) || defined(__HAIKU__) || defined(_WIN32) || defined(SDLMAME_NO64BITIO) || defined(__ANDROID__) || defined(__DEVKITPRO__)
 	fd = ::open(dst.c_str(), access, 0666);
 #else
 	fd = ::open64(dst.c_str(), access, 0666);
@@ -285,7 +285,7 @@ std::error_condition osd_file::open(std::string const &path, std::uint32_t openf
 				// attempt to reopen the file
 				if (!createrr)
 				{
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__bsdi__) || defined(__DragonFly__) || defined(__HAIKU__) || defined(_WIN32) || defined(SDLMAME_NO64BITIO) || defined(__ANDROID__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__bsdi__) || defined(__DragonFly__) || defined(__HAIKU__) || defined(_WIN32) || defined(SDLMAME_NO64BITIO) || defined(__ANDROID__) || defined(__DEVKITPRO__)
 					fd = ::open(dst.c_str(), access, 0666);
 #else
 					fd = ::open64(dst.c_str(), access, 0666);
@@ -306,7 +306,7 @@ std::error_condition osd_file::open(std::string const &path, std::uint32_t openf
 	}
 
 	// get the file size
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__bsdi__) || defined(__DragonFly__) || defined(__HAIKU__) || defined(_WIN32) || defined(SDLMAME_NO64BITIO) || defined(__ANDROID__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__bsdi__) || defined(__DragonFly__) || defined(__HAIKU__) || defined(_WIN32) || defined(SDLMAME_NO64BITIO) || defined(__ANDROID__) || defined(__DEVKITPRO__)
 	struct stat st;
 	if (::fstat(fd, &st) < 0)
 #else
@@ -371,7 +371,7 @@ bool osd_get_physical_drive_geometry(const char *filename, uint32_t *cylinders, 
 
 std::unique_ptr<osd::directory::entry> osd_stat(const std::string &path)
 {
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__bsdi__) || defined(__DragonFly__) || defined(__HAIKU__) || defined(_WIN32) || defined(SDLMAME_NO64BITIO) || defined(__ANDROID__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__bsdi__) || defined(__DragonFly__) || defined(__HAIKU__) || defined(_WIN32) || defined(SDLMAME_NO64BITIO) || defined(__ANDROID__) || defined(__DEVKITPRO__)
 	struct stat st;
 	int const err = ::stat(path.c_str(), &st);
 #else

--- a/src/osd/modules/file/posixptty.cpp
+++ b/src/osd/modules/file/posixptty.cpp
@@ -109,7 +109,7 @@ bool posix_check_ptty_path(std::string const &path) noexcept
 
 std::error_condition posix_open_ptty(std::uint32_t openflags, osd_file::ptr &file, std::uint64_t &filesize, std::string &name) noexcept
 {
-#if defined(__ANDROID__)
+#if defined(__ANDROID__) || defined(__DEVKITPRO__)
 	return std::errc::not_supported; // TODO: revisit this error code
 #else // defined(__ANDROID__)
 	// TODO: handling of the slave path is insecure - should use ptsname_r/ttyname_r in a loop

--- a/src/osd/modules/file/posixsocket.cpp
+++ b/src/osd/modules/file/posixsocket.cpp
@@ -24,7 +24,9 @@
 #include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/time.h>
+#ifndef __DEVKITPRO__
 #include <sys/un.h>
+#endif
 #include <unistd.h>
 
 
@@ -211,6 +213,9 @@ bool posix_check_domain_path(std::string const &path) noexcept
 
 std::error_condition posix_open_socket(std::string const &path, std::uint32_t openflags, osd_file::ptr &file, std::uint64_t &filesize) noexcept
 {
+	#if defined(__DEVKITPRO__)
+	return std::errc::not_supported;
+	#else
 	char hostname[256];
 	int port;
 	std::sscanf(&path[strlen(posixfile_socket_identifier)], "%255[^:]:%d", hostname, &port);
@@ -239,11 +244,15 @@ std::error_condition posix_open_socket(std::string const &path, std::uint32_t op
 	}
 
 	return create_socket(sai, sock, openflags, file, filesize);
+	#endif
 }
 
 
 std::error_condition posix_open_domain(std::string const &path, std::uint32_t openflags, osd_file::ptr &file, std::uint64_t &filesize) noexcept
 {
+	#if defined(__DEVKITPRO__)
+	return std::errc::not_supported;
+	#else
 	struct sockaddr_un sau;
 	memset(&sau, 0, sizeof(sau));
 	sau.sun_family = AF_UNIX;
@@ -261,4 +270,5 @@ std::error_condition posix_open_domain(std::string const &path, std::uint32_t op
 	}
 
 	return create_socket(sau, sock, openflags, file, filesize);
+	#endif
 }

--- a/src/osd/modules/lib/osdlib.h
+++ b/src/osd/modules/lib/osdlib.h
@@ -21,6 +21,7 @@
 #include <type_traits>
 #include <vector>
 #include <memory>
+#include <cstdint>
 
 /*-----------------------------------------------------------------------------
     osd_process_kill: kill the current process

--- a/src/osd/modules/lib/osdlib_retro.cpp
+++ b/src/osd/modules/lib/osdlib_retro.cpp
@@ -8,8 +8,10 @@
 #include <windows.h>
 #include <memoryapi.h>
 #else
+#ifndef __DEVKITPRO__
 #include <dlfcn.h>
 #include <sys/mman.h>
+#endif
 #include <sys/time.h>
 #include <unistd.h>
 #endif
@@ -29,6 +31,7 @@ const char *osd_getenv(const char *name)
     return getenv(name);
 }
 
+#ifndef __DEVKITPRO__
 //============================================================
 //  osd_setenv
 //============================================================
@@ -57,6 +60,7 @@ int osd_setenv(const char *name, const char *value, int overwrite)
    return setenv(name, value, overwrite);
 #endif
 }
+#endif
 
 //============================================================
 //  osd_process_kill
@@ -64,7 +68,9 @@ int osd_setenv(const char *name, const char *value, int overwrite)
 
 void osd_process_kill(void)
 {
-#ifndef _WIN32
+#if defined(__DEVKITPRO__)
+		abort();
+#elif !defined(_WIN32)
     kill(getpid(), SIGKILL);
 #else
     TerminateProcess(GetCurrentProcess(), -1);
@@ -72,6 +78,7 @@ void osd_process_kill(void)
 }
 
 
+#ifndef __DEVKITPRO__
 //============================================================
 //  osd_alloc_executable
 //
@@ -102,6 +109,7 @@ void osd_free_executable(void *ptr, size_t size)
 	munmap(ptr, size);
 #endif
 }
+#endif
 
 //============================================================
 //  osd_break_into_debugger
@@ -209,7 +217,7 @@ private:
 	std::vector<std::string> m_libraries;
 	HMODULE                  m_module = nullptr;
 };
-#else
+#elif !defined(__DEVKITPRO__)
 class dynamic_module_posix_impl : public dynamic_module
 {
 public:
@@ -277,6 +285,7 @@ bool invalidate_instruction_cache(void const *start, std::size_t size)
 #endif
 }
 
+#ifndef __DEVKITPRO__
 void *virtual_memory_allocation::do_alloc(std::initializer_list<std::size_t> blocks, unsigned intent, std::size_t &size, std::size_t &page_size)
 {
 #if defined(_WIN32)
@@ -349,7 +358,9 @@ bool virtual_memory_allocation::do_set_access(void *start, std::size_t size, uns
 	return mprotect(reinterpret_cast<char *>(start), size, prot) == 0;
 #endif
 }
+#endif
 
+#ifndef __DEVKITPRO__
 dynamic_module::ptr dynamic_module::open(std::vector<std::string> &&names)
 {
 #if defined(_WIN32)
@@ -358,5 +369,6 @@ dynamic_module::ptr dynamic_module::open(std::vector<std::string> &&names)
 	return std::make_unique<dynamic_module_posix_impl>(std::move(names));
 #endif
 }
+#endif
 
 } // namespace osd


### PR DESCRIPTION
Initial work to get SAME_CDI running on the nintendo switch through libnx.

Closes #11 

# Working:
- BIOS
- ISO/CUE roms
- Gameplay, input, video, audio etc...
- Tested with "Link: The Faces of Evil" and "Hotel Mario"
- Running at full speed or near full speed

# Not working
- CHD roms (decompression error)
- Audio is crackly sometimes
- JIT (x86 only) (not sure if needed performance-wise)

# Notes
- Includes import change from #19
- Requires my RetroArch branch: [blueberrymuffin3/RetroArch#same-cdi-switch](https://github.com/blueberrymuffin3/RetroArch/tree/same-cdi-switch) (Plan to upstream once everything is working)

# Building
1. Install dependencies (see [LibRetro Wiki](https://docs.libretro.com/development/retroarch/compilation/switch-libnx/))
2. Build SAME_CDI: `make -f Makefile.libretro platform=libnx -j4`
3. Copy `same_cdi/same_cdi_libretro.a` to `RetroArch/libretro_libnx.a`
4. Build RetroArch: `make -f Makefile.libnx -Bj10`

# Running
1. Install RetroArch
2. Build or use my binary: [same_cdi_libretro_libnx.zip](https://github.com/user-attachments/files/19711638/same_cdi_libretro_libnx.zip)
3. Copy NRO to `/retroarch/cores/same_cdi_libretro_libnx.nro` on SD

> Note: Can probably be tested in switch emulator, but I'm not sure

# Screenshots/Videos
TODO

# Still needed
- [ ] BuildBot integration
- [ ] Possibly avoid changes to vendored dependencies (Are the Lua/SQLite/linenoise libraries actually  needed/used?)
- [ ] Use proper defines/build flags (probably `__SWITCH__` or `HAS_LIBNX` instead of `__DEVKITPRO__`)